### PR TITLE
goctl for vscode 0.1.6

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,13 +1,24 @@
+## v0.1.6
+
+### Support
+
+* `@handler` annotation syntax highlighting.
+* support for route jump without returns to definition.
+
+### Fixed
+
+* fix some syntax highlighting errors, example `get /greet/to/:name`.
+
 ## v0.1.5
 
 ### Optimize
 
-- Add go-zero logo.
-- Optimize the formatting logic, when formatting the file, there is no need to save the file to disk.
+* Add go-zero logo.
+* Optimize the formatting logic, when formatting the file, there is no need to save the file to disk.
 
 ### Fixed
 
-- Fix the bug that the file cannot be saved when the user sets `editor.formatOnSave` is `true`.
+* Fix the bug that the file cannot be saved when the user sets `editor.formatOnSave` is `true`.
 
 **Note:** To upgrade this version, please make sure that the goctl command line tool is also upgraded to the latest version. To upgrade the goctl command line tool, you can rerun the [goctl command line tool installation](https://github.com/tal-tech/go-zero#5-quick-start) command.
 
@@ -15,11 +26,11 @@
 
 ### Snippet improvements
 
-- Add `@handler` snippet.
-- Add go style snippet (`tys` and `im`).
+* Add `@handler` snippet.
+* Add go style snippet (`tys` and `im`).
 
 ## v0.1.3
 
 ### Fixed
 
-- Fixed cannot be jump to code definition in some cases.
+* Fixed cannot be jump to code definition in some cases.

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "goctl",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "goctl",
     "displayName": "goctl",
     "description": "goctl visual studio code extension",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "publisher": "xiaoxin-technology",
     "icon": "images/go-zero-logo.png",
     "engines": {

--- a/vscode/src/goctlDeclaration.ts
+++ b/vscode/src/goctlDeclaration.ts
@@ -21,7 +21,7 @@ function REX_URL_RETURN(target: string): string {
 }
 
 function REX_URL_METHOD(target: string): string {
-	return `\\(\\s*\\b${target}\\b\\s*\\)\\s*returns`;
+	return `\\(\\s*\\b${target}\\b\\s*\\)`;
 }
 
 export class GoctlDefinitionProvider implements vscode.DefinitionProvider {

--- a/vscode/syntaxes/goctl.tmLanguage.json
+++ b/vscode/syntaxes/goctl.tmLanguage.json
@@ -499,13 +499,16 @@
 					"include": "#doc"
 				},
 				{
+					"include": "#server"
+				},
+				{
 					"include": "#handler"
 				}
 			]
 		},
 		"method": {
 			"name": "method.service.goctl",
-			"begin": "(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|get|head|post|put|delete|connect|options|trace|patch)\\s*(/[A-Za-z][A-Za-z0-9_/:-]*)",
+			"begin": "(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|get|head|post|put|delete|connect|options|trace|patch)\\s*((/[A-Za-z][A-Za-z0-9_/:-]*)|\\s|\\n)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.other.goctl"
@@ -514,7 +517,7 @@
 					"name": "entity.name.function"
 				}
 			},
-			"end": "\\)",
+			"end": "(\\)|\\n|\\s)",
 			"patterns": [
 				{
 					"include": "#comments"
@@ -541,7 +544,7 @@
 					"name": "entity.name.function"
 				}
 			},
-			"end": "\\)",
+			"end": "(\\)|\\n)",
 			"patterns": [
 				{
 					"include": "#comments"
@@ -559,14 +562,24 @@
 			"begin": "@doc",
 			"end": "\\)"
 		},
-		"handler": {
-			"name": "method.handle.service.goctl",
-			"begin": "@server",
+		"server": {
+			"name": "method.server.service.goctl",
+			"begin": "@server\\(",
 			"end": "\\)",
 			"patterns": [
 				{
 					"include": "#handlerKeywords"
 				},
+				{
+					"include": "#ident"
+				}
+			]
+		},
+		"handler": {
+			"name": "method.handle.service.goctl",
+			"begin": "@handler",
+			"end": "\\n",
+			"patterns": [
 				{
 					"include": "#ident"
 				}


### PR DESCRIPTION
### Support

* `@handler` annotation syntax highlighting.
* support for route jump without returns to definition.

### Fixed

* fix some syntax highlighting errors, example `get /greet/to/:name`.